### PR TITLE
#36: If we're reconnecting, reset _all_ internal state.

### DIFF
--- a/dotscience/__init__.py
+++ b/dotscience/__init__.py
@@ -253,6 +253,9 @@ class Dotscience:
     currentRun = None
 
     def __init__(self):
+        self._reset()
+
+    def _reset(self):
         self._mode = None
         self._workload_file = None
         self._root = os.getenv('DOTSCIENCE_PROJECT_DOT_ROOT', default=os.getcwd())
@@ -269,6 +272,7 @@ class Dotscience:
         # TODO: make publish etc fail if we're not connected in remote mode.
         if not project:
             raise Exception("Please specify a project name as the third argument to ds.connect()")
+        self._reset()
         self._dotmesh_client = DotmeshClient(
             cluster_url=hostname + "/v2/dotmesh/rpc",
             username=username,

--- a/dotscience/test_dotscience.py
+++ b/dotscience/test_dotscience.py
@@ -857,3 +857,39 @@ def test_multi_publish_2():
     assert m1["__ID"] != m2["__ID"]
     assert m1["start"] != m2["start"]
     assert m1["end"] != m2["end"]
+
+
+def test_reconnect_resets_internal_state(monkeypatch):
+    class FakeDotmeshClient:
+        def __init__(self, cluster_url, username, api_key):
+            self.cluster_url = cluster_url
+            self.username = username
+            self.api_key = api_key
+
+        def ping(self):
+            pass
+
+    monkeypatch.setattr(dotscience, "DotmeshClient", FakeDotmeshClient)
+
+    ds = dotscience.Dotscience()
+    ds.connect("me", "pass", "myproj", "https://example.com")
+    assert ds._dotmesh_client.__dict__ == {
+        "cluster_url": "https://example.com/v2/dotmesh/rpc",
+        "username": "me",
+        "api_key": "pass",
+    }
+    assert ds._project_name == "myproj"
+
+    # Pretend we have a cached project:
+    ds._cached_project = "not empty"
+    assert ds._get_project_or_create("myproj") == "not empty"
+
+    # Now, reconnect:
+    ds.connect("me2", "pass2", "myproj2", "https://2.example.com")
+    assert ds._dotmesh_client.__dict__ == {
+        "cluster_url": "https://2.example.com/v2/dotmesh/rpc",
+        "username": "me2",
+        "api_key": "pass2",
+    }
+    assert ds._project_name == "myproj2"
+    assert ds._cached_project == None


### PR DESCRIPTION
Fixes #36 

This doesn't cover the problem of "we restarted Jupyter kernel and it still reconnected to wrong project" but—I can't reproduce that case. So possibly it was single notebook that did connect(A) and then connect(B), in which case restarting kernel wouldn't help.